### PR TITLE
[JENKINS-30776] The dependency to maven-plugin should be optional.

### DIFF
--- a/src/main/java/hudson/plugins/doclinks/DocLinksPublisher.java
+++ b/src/main/java/hudson/plugins/doclinks/DocLinksPublisher.java
@@ -26,6 +26,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.servlet.ServletException;
+import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.QueryParameter;
@@ -125,6 +126,9 @@ public class DocLinksPublisher extends Recorder {
 
         @Override
         public boolean isApplicable(final Class<? extends AbstractProject> jobType) {
+            if (Jenkins.getInstance().getPlugin("maven-plugin") == null) {
+                return true;
+            }
             return !AbstractMavenProject.class.isAssignableFrom(jobType);
         }
 

--- a/src/main/java/hudson/plugins/doclinks/m2/DocLinksMavenReporter.java
+++ b/src/main/java/hudson/plugins/doclinks/m2/DocLinksMavenReporter.java
@@ -40,7 +40,7 @@ public class DocLinksMavenReporter extends MavenReporter {
 
     private static final long serialVersionUID = 1L;
 
-    @Extension
+    @Extension(optional=true)
     public static final MavenReporterDescriptor DESCRIPTOR = new DocLinksMavenReporterDescriptor();
 
     private final List<Document> documents;


### PR DESCRIPTION
[JENKINS-30776](https://issues.jenkins-ci.org/browse/JENKINS-30776)

Users can install doclinks-plugin without maven-plugin, as its dependency is defined optional.
https://github.com/jenkinsci/doclinks-plugin/blob/doclinks-0.6/pom.xml#L125

doclinks-plugin-0.6 causes following problems without maven-plugin:
* Error logs when launching Jenkins (caused for `DocLinksMavenReporter`).
* Outputs errors when access project configuration pages (JENKINS-30776).
